### PR TITLE
Bugfixes

### DIFF
--- a/comdirect_api/comdirect_client.py
+++ b/comdirect_api/comdirect_client.py
@@ -46,6 +46,12 @@ class ComdirectClient(
                 self.session = pickle.load(input)
                 self.auth_service = pickle.load(input)
 
+            # Es gibt im session-Objekt ein auth-Objekt
+            # Es gibt im auth_service-Objekt ein session-Objekt
+            # Alle sind nach pickle.load verschieden!
+            self.auth_service.session = self.session
+            self.session.auth = self.auth_service.auth
+
     def session_export(self, filename: str = "session.pkl"):
         with open(filename, "wb") as output:
             pickle.dump(self.session, output, pickle.HIGHEST_PROTOCOL)

--- a/comdirect_api/service/order_service.py
+++ b/comdirect_api/service/order_service.py
@@ -27,8 +27,8 @@ class OrderService:
         """
         kwargs_mapping = {
             "instrument_id": "instrumentId",
-            "wkn": "WKN",
-            "isin": "ISIN",
+            "wkn": "wkn",          # Dokumentation ist falsch, wkn muss klein geschrieben werden!
+            "isin": "isin",
             "mneomic": "mneomic",
             "venue_id": "venueId",
             "side": "side",
@@ -45,7 +45,8 @@ class OrderService:
                 raise ValueError("Keyword argument {} is invalid".format(arg))
             else:
                 params[api_arg] = val
-        response = self.session.get(url, json=params).json()
+ 
+        response = self.session.get(url, params=params).json()
         return response
 
     def get_all_orders(


### PR DESCRIPTION
Bugfixes: 

Die gegenseitigen Referenzen im comdirect_client-objekt müssen nach pickle.load wiederhergestellt werden. Ansonsten gibt es Probleme, spätestens wenn man die Session nach dem Import wieder exportiert,

Kleine Korrekturen in order_service.py. Die API-Dokumentation von Comdirect ist an dieser Stelle falsch. Ich habe die schon um eine Korrektur gebeten, aber die haben bislang nichts gemacht.

Ich habe alle Bugfixes ausgiebig getestet.