### PR TITLE
Add account listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an unofficial python wrapper for the comdirect API for private consumers
 
 This package currently supports the following operations:
 
-* Read balances and transactions
+* Read account information, balances and transactions
 * Read depot information
 * Read and download Documents
 * Read and update orders
@@ -57,6 +57,13 @@ The the client is now ready for use, for example:
 ```python
 balances = client.get_all_balances()
 print(balances['values'])
+```
+
+You can fetch account master data separately:
+
+```python
+accounts = client.get_accounts()
+print(accounts['values'])
 ```
 
 It is also possible to send a GET request to a self defined endpoint, for example:

--- a/comdirect_api/service/account_service.py
+++ b/comdirect_api/service/account_service.py
@@ -2,6 +2,20 @@ from typing import Any
 
 
 class AccountService:
+    def get_accounts(self, without_account: bool = False) -> Any:
+        """4.1.0. Request for account information for all accounts.
+
+        Args:
+            without_account (bool, optional): Suppresses the master data of the accounts. Defaults to False.
+
+        Returns:
+            Any: Response object
+        """
+        url = "{0}/banking/clients/user/v2/accounts".format(self.api_url)
+        params = {"without-attr": "account"} if without_account else None
+        response = self.session.get(url, params=params).json()
+        return response
+
     def get_all_balances(self, without_account: bool = False) -> Any:
         """4.1.1. Request for account information, including cash balance and buying power, for all accounts.
 

--- a/tests/test_comdirect_client.py
+++ b/tests/test_comdirect_client.py
@@ -3,6 +3,24 @@ import os
 from comdirect_api.comdirect_client import ComdirectClient
 
 
+class DummyResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def json(self):
+        return self.payload
+
+
+class DummySession:
+    def __init__(self, payload):
+        self.payload = payload
+        self.requests = []
+
+    def get(self, url, params=None):
+        self.requests.append((url, params))
+        return DummyResponse(self.payload)
+
+
 def test_comdirect_client_fresh_init():
     client_id = "dummy_id"
     client_secret = "dummy_secret"
@@ -37,3 +55,32 @@ def test_comdirect_client_import_session(tmp_path):
 
     assert new_client.auth_service.client_id == client_id
     assert new_client.auth_service.client_secret == client_secret
+
+
+def test_get_accounts():
+    client = ComdirectClient("dummy_id", "dummy_secret")
+    payload = {"values": [{"accountId": "account-id"}]}
+    client.session = DummySession(payload)
+
+    response = client.get_accounts()
+
+    assert response == payload
+    assert client.session.requests == [
+        ("https://api.comdirect.de/api/banking/clients/user/v2/accounts", None)
+    ]
+
+
+def test_get_accounts_without_account():
+    client = ComdirectClient("dummy_id", "dummy_secret")
+    payload = {"values": []}
+    client.session = DummySession(payload)
+
+    response = client.get_accounts(without_account=True)
+
+    assert response == payload
+    assert client.session.requests == [
+        (
+            "https://api.comdirect.de/api/banking/clients/user/v2/accounts",
+            {"without-attr": "account"},
+        )
+    ]


### PR DESCRIPTION
## Summary
- add get_accounts() for the banking/clients/user/v2/accounts endpoint
- support the without_account flag consistently with get_all_balances()
- document the new method in the README

## Tests
- .venv/bin/python -m pytest